### PR TITLE
Fixed nullable types in method signatures

### DIFF
--- a/externallib.php
+++ b/externallib.php
@@ -1024,7 +1024,7 @@ class api_extend extends external_api
      * @throws invalid_parameter_exception
      * @throws required_capability_exception
      */
-    public static function update_assign_activity(int $instance_id, int $starting_date = null, int $deadline = null, int $cut_off = null)
+    public static function update_assign_activity(int $instance_id, ?int $starting_date = null, ?int $deadline = null, ?int $cut_off = null)
     {
         global $DB;
 
@@ -1118,7 +1118,7 @@ class api_extend extends external_api
      * @throws invalid_parameter_exception
      * @throws required_capability_exception
      */
-    public static function update_quiz_activity(int $instance_id, int $starting_date = null, int $cut_off = null)
+    public static function update_quiz_activity(int $instance_id, ?int $starting_date = null, ?int $cut_off = null)
     {
         global $DB;
 

--- a/version.php
+++ b/version.php
@@ -22,7 +22,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2026011602;
+$plugin->version  = 2026021900;
 $plugin->requires = 2018051700;  // Requires this Moodle version - at least 2.0
 $plugin->component = 'local_api_extend';
 $plugin->release = '0.2';


### PR DESCRIPTION
Eliminate all PHP deprecation warnings related to nullable parameters in the api_extend plugin by explicitly declaring nullable types in method signatures, ensuring forward compatibility with PHP 8.1 and later versions.