### PR TITLE
Moodle 5.1

### DIFF
--- a/externallib.php
+++ b/externallib.php
@@ -114,8 +114,8 @@ class api_extend extends external_api
         return new external_single_structure(
             [
                 'id' => new external_value(PARAM_INT, 'Assignment id'),
-                'duedate' => new external_value(PARAM_INT, 'Due Date', VALUE_OPTIONAL, null),
-                'cutoffdate' => new external_value(PARAM_INT, 'Cut off Date', VALUE_OPTIONAL, null)
+                'duedate' => new external_value(PARAM_INT, 'Due Date', VALUE_DEFAULT, null, NULL_ALLOWED),
+                'cutoffdate' => new external_value(PARAM_INT, 'Cut off Date', VALUE_DEFAULT, null, NULL_ALLOWED)
             ]
         );
     }
@@ -475,7 +475,7 @@ class api_extend extends external_api
         return new external_function_parameters([
             'assignmentid' => new external_value(PARAM_INT, 'The assignment id'),
             'userid' => new external_value(PARAM_INT, 'The user id'),
-            'submissionid' => new external_value(PARAM_INT, 'The submission id', VALUE_OPTIONAL)
+            'submissionid' => new external_value(PARAM_INT, 'The submission id', VALUE_DEFAULT, null, NULL_ALLOWED)
         ]);
     }
 

--- a/externallib.php
+++ b/externallib.php
@@ -1024,7 +1024,7 @@ class api_extend extends external_api
      * @throws invalid_parameter_exception
      * @throws required_capability_exception
      */
-    public static function update_assign_activity(int $instance_id, int $starting_date = null, int $deadline = null, int $cut_off = null)
+    public static function update_assign_activity(int $instance_id, ?int $starting_date = null, ?int $deadline = null, ?int $cut_off = null)
     {
         global $DB;
 
@@ -1118,7 +1118,7 @@ class api_extend extends external_api
      * @throws invalid_parameter_exception
      * @throws required_capability_exception
      */
-    public static function update_quiz_activity(int $instance_id, int $starting_date = null, int $cut_off = null)
+    public static function update_quiz_activity(int $instance_id, ?int $starting_date = null, ?int $cut_off = null)
     {
         global $DB;
 

--- a/version.php
+++ b/version.php
@@ -22,7 +22,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2026011602;
+$plugin->version  = 2026021900;
 $plugin->requires = 2018051700;  // Requires this Moodle version - at least 2.0
 $plugin->component = 'local_api_extend';
 $plugin->release = '0.2';

--- a/version.php
+++ b/version.php
@@ -22,7 +22,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2026021900;
+$plugin->version  = 2026022400;
 $plugin->requires = 2018051700;  // Requires this Moodle version - at least 2.0
 $plugin->component = 'local_api_extend';
 $plugin->release = '0.2';


### PR DESCRIPTION
In newer Moodle versions, VALUE_OPTIONAL is not allowed for top-level function parameters (it’s only valid for keys inside external_single_structure / external_multiple_structure). For a top-level optional parameter you must use VALUE_DEFAULT (with a default value).